### PR TITLE
fixes to get rollup working

### DIFF
--- a/src/EsriLeafletRenderers.js
+++ b/src/EsriLeafletRenderers.js
@@ -1,6 +1,6 @@
 export { version as VERSION } from '../package.json';
 
-export { Renderer, renderer } from './Renderers/Renderer';
+export { Renderer } from './Renderers/Renderer';
 export { SimpleRenderer, simpleRenderer } from './Renderers/SimpleRenderer';
 export { ClassBreaksRenderer, classBreaksRenderer } from './Renderers/ClassBreaksRenderer';
 export { UniqueValueRenderer, uniqueValueRenderer } from './Renderers/UniqueValueRenderer';

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -1,4 +1,4 @@
-// import L from 'leaflet';
+ import L from 'leaflet';
 // import { FeatureLayer } from 'esri-leaflet';
 
 import classBreaksRenderer from './Renderers/ClassBreaksRenderer';

--- a/src/Renderers/Renderer.js
+++ b/src/Renderers/Renderer.js
@@ -106,8 +106,4 @@ export var Renderer = L.Class.extend({
   }
 });
 
-export function renderer (rendererJson, options) {
-  return new Renderer(rendererJson, options);
-}
-
-export default renderer;
+export default Renderer;


### PR DESCRIPTION
@jgravois I added the import for L which fixed the problem where:
`L$1 = 'default' in L$1 ? L$1['default'] : L$1;`

This caused the tests to fail but changing the way the base Renderer class was exported fixed that problem.
